### PR TITLE
Move deactivate hook to uninstall

### DIFF
--- a/yext-ai-search-for-wordpress.php
+++ b/yext-ai-search-for-wordpress.php
@@ -34,7 +34,7 @@ require_once YEXT_INC . '/blocks.php';
 
 // Activation/Deactivation.
 register_activation_hook( __FILE__, '\Yext\Core\activate' );
-register_deactivation_hook( __FILE__, '\Yext\Core\deactivate' );
+register_uninstall_hook( __FILE__, '\Yext\Core\deactivate' );
 
 // Bootstrap.
 Yext\Core\setup();


### PR DESCRIPTION
@rdimascio Passing this over to you for CR. I moved the deactivation hook to uninstall because we are resetting the option values to default. Thanks!